### PR TITLE
DON'T MERGE. Refactor (avoiding recursion).

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,18 +1,17 @@
+function _recursive_rendering(string, context, stack) {
+  return Object.keys(context)
+    .reduce(function (acc, key) {
+      var newStack = stack ? stack + '.' : '';
+      var find = '\\$\\{\\s*' + newStack + key + '\\s*\\}';
+      var re = new RegExp(find, 'g');
+
+      if (typeof context[key] === 'object') {
+        return _recursive_rendering(acc, context[key], newStack + key);
+      }
+      return acc.replace(re, context[key]);
+    }, string);
+}
+
 module.exports = function (string, context) {
   return _recursive_rendering(string, context, '');
 };
-
-function _recursive_rendering(string, context, stack) {
-  for (var key in context) {
-    if (context.hasOwnProperty(key)) {
-      if(typeof context[key] === "object") {
-        string = _recursive_rendering(string, context[key], (stack?stack+'.':'')+ key);
-      } else {
-        var find = '\\$\\{\\s*' + (stack?stack +'.':'') + key + '\\s*\\}';
-        var re = new RegExp(find, 'g');
-        string = string.replace(re, context[key]);
-      }
-    }
-  }
-  return string;
-}


### PR DESCRIPTION
**DON'T MERGE IT YET**

I did this version thinking it would be faster. Here I'm just calling replace once, and there is no recursion, and knowing that regex are accelerated it should be faster... but I did some benchmarks and it seems to be the other way around.

I think the code is cleaner, but also maybe is harder to understand. I should try to do more benchmarks, maybe I didn't do them in the right way, or I'm not understanding well the results.
